### PR TITLE
Fix timer interval 

### DIFF
--- a/G2DManager_s.lua
+++ b/G2DManager_s.lua
@@ -912,7 +912,7 @@ function processExpired(isEnd)
 		setTimer(function()
 			G2D.StartTick = getTickCount()
 			coroutine.resume(G2D.Running[1])
-		end,10,1)
+		end,50,1)
 	else
 		G2DStart()
 	end


### PR DESCRIPTION
Change timer interval to 50 because you can't use under 50 in old server versions 
![image](https://user-images.githubusercontent.com/30420446/65814093-3f2aad80-e1e6-11e9-8176-161b3bf55b54.png)
or you can simply change the min server version in meta to 1.5.6 r16715
