### PR TITLE
Fix performancebrowser cursor

### DIFF
--- a/dxCmdEvent.lua
+++ b/dxCmdEvent.lua
@@ -191,7 +191,7 @@ dgsCmdAddCommandHandler("performancebrowser",function(cmd)
 		dgsWindowSetSizable(performanceBrowser["window"],false)
 		dgsBringToFront(performanceBrowser["window"])
 		outputCmdMessage(cmd,"Performance Browser Status Monitor: ON")
-		dgsShowCursor(true,"dx")
+		dgsShowCursor(true,"performance")
 	else
 		outputCmdMessage(cmd,"Performance Browser Monitor: OFF")
 		dgsCloseWindow(performanceBrowser["window"])
@@ -345,13 +345,15 @@ function netUpdate()
 	end
 end
 
-addEventHandler("onDgsDestroy",root,function()
+addEventHandler("onDgsDestroy",resourceRoot,function()
 	if source == cmdSystem["window"] then
 		dgsShowCursor(false,"cmd")
 	elseif source == netSystem["window"] then
 		dgsShowCursor(false,"net")
 	elseif source == dxStatus["window"] then
 		dgsShowCursor(false,"dx")
+	elseif source == performanceBrowser["window"] then 
+		dgsShowCursor(false,"performance")
 	end
 end)
 

--- a/dxCmdEvent.lua
+++ b/dxCmdEvent.lua
@@ -103,7 +103,7 @@ end
 addCommandHandler("cmd",dgsBuildInCMD)
 addCommandHandler("dgscmd",dgsBuildInCMD)
 
-addEventHandler("onDgsWindowClose",root,function()
+addEventHandler("onDgsWindowClose",resourceRoot,function()
 	if source == cmdSystem["window"] then
 		cancelEvent()
 		for k,v in pairs(cmdSystem) do
@@ -419,7 +419,7 @@ function dxStatusUpdate()
 end
 addEvent("onDGSObjectRender",true)
 addEvent("onAnimationWindowCreate",true)
-addEventHandler("onAnimationWindowCreate",root,function()
+addEventHandler("onAnimationWindowCreate",resourceRoot,function()
 	if source == netSystem["window"] then
 		netSystem["Sent"] = dgsCreateLabel(10,10,100,30,"Send",false,netSystem["window"],_,1.6,1.6)
 		netSystem["ByteSent"] = dgsCreateLabel(10,50,200,20,"Bytes:",false,netSystem["window"],_,1.2,1.2)


### PR DESCRIPTION
if you opened the performance browser the cursor will be still shown if you close the cmd,
and I noticed some events use `root` instead of `resourceRoot`