### PR TITLE
Add auto scrolling down to cmd

### DIFF
--- a/plugin/cmd.lua
+++ b/plugin/cmd.lua
@@ -162,6 +162,7 @@ function outputCmdMessage(cmd,str)
 	dgsMemoAppendText(cmd,str.."\n",true)
 	local textTable = dgsElementData[cmd].text
 	dgsMemoSetCaretPosition(cmd,textTable[#textTable][-1])
+	dgsMemoSetVerticalScrollPosition(cmd,100)
 end
 
 function receiveCmdEditInput(cmd,str)


### PR DESCRIPTION
You don't have to scroll down manually when you enter something on CMD

**Note:** This should be merged after fixing #64 to avoid errors


