### PR TITLE
Add dgsComboBoxAdjustBoxHeight function

### DIFF
--- a/Core/combobox.lua
+++ b/Core/combobox.lua
@@ -78,6 +78,7 @@ function dgsCreateComboBox(x,y,sx,sy,caption,relative,parent,itemheight,textColo
 	dgsSetData(combobox,"clip",false)
 	dgsSetData(combobox,"wordbreak",false)
 	dgsSetData(combobox,"itemHeight",itemheight or styleSettings.combobox.itemHeight)
+	dgsSetData(combobox,"viewCount",false,true)
 	dgsSetData(combobox,"colorcoded",false)
 	dgsSetData(combobox,"listState",-1,true)
 	dgsSetData(combobox,"listStateAnim",-1)
@@ -485,10 +486,19 @@ function dgsComboBoxGetScrollPosition(combobox)
 	return dgsScrollBarGetScrollPosition(scb)
 end
 
-function dgsComboBoxAdjustBoxHeight(combobox,count)
-	assert(dgsGetType(combobox) == "dgs-dxcombobox","Bad argument @dgsComboBoxAdjustBoxHeight at at argument 1, expect dgs-dxcombobox got "..dgsGetType(combobox))
-	local count = tonumber (count) or dgsComboBoxGetItemCount(combobox)
-	return dgsComboBoxSetBoxHeight (combobox,math.max(count,1) * dgsGetData(combobox,"itemHeight"))
+function dgsComboBoxSetViewCount(combobox,count)
+	assert(dgsGetType(combobox) == "dgs-dxcombobox","Bad argument @dgsComboBoxSetViewCount at at argument 1, expect dgs-dxcombobox got "..dgsGetType(combobox))
+	if type(count) == "number" then
+		dgsSetData(combobox,"viewCount",count,true)
+		return dgsComboBoxSetBoxHeight (combobox,count * dgsGetData(combobox,"itemHeight"))
+	else
+		return dgsSetData (combobox,"viewCount",false,true)
+	end
+end
+
+function dgsComboBoxGetViewCount(combobox,count)
+	assert(dgsGetType(combobox) == "dgs-dxcombobox","Bad argument @dgsComboBoxGetViewCount at at argument 1, expect dgs-dxcombobox got "..dgsGetType(combobox))
+	return dgsElementData[combobox].viewCount
 end
 
 ----------------------------------------------------------------

--- a/Core/combobox.lua
+++ b/Core/combobox.lua
@@ -485,6 +485,12 @@ function dgsComboBoxGetScrollPosition(combobox)
 	return dgsScrollBarGetScrollPosition(scb)
 end
 
+function dgsComboBoxAdjustBoxHeight(combobox,count)
+	assert(dgsGetType(combobox) == "dgs-dxcombobox","Bad argument @dgsComboBoxAdjustBoxHeight at at argument 1, expect dgs-dxcombobox got "..dgsGetType(combobox))
+	local count = tonumber (count) or dgsComboBoxGetItemCount(combobox)
+	return dgsComboBoxSetBoxHeight (combobox,math.max(count,1) * dgsGetData(combobox,"itemHeight"))
+end
+
 ----------------------------------------------------------------
 --------------------------Renderer------------------------------
 ----------------------------------------------------------------

--- a/manager.lua
+++ b/manager.lua
@@ -409,6 +409,10 @@ function dgsSetData(element,key,value,nocheck)
 						configComboBox(element)
 					elseif key == "listState" then
 						triggerEvent("onDgsComboBoxStateChange",element,value == 1 and true or false)
+					elseif key == "viewCount" then
+						dgsComboBoxSetViewCount(element,value)
+					elseif key == "itemHeight" and dgsElementData[element].viewCount then
+						dgsComboBoxSetViewCount(element,dgsElementData[element].viewCount)
 					end
 				elseif dgsType == "dgs-dxtabpanel" then
 					if key == "selected" then

--- a/meta.xml
+++ b/meta.xml
@@ -289,7 +289,8 @@
 	<export function="dgsComboBoxGetEditEnabled" type="client" />
 	<export function="dgsComboBoxGetText" type="client" />
 	<export function="dgsComboBoxGetItemCount" type="client" />
-	<export function="dgsComboBoxAdjustBoxHeight" type="client" />
+	<export function="dgsComboBoxSetViewCount" type="client" />
+	<export function="dgsComboBoxGetViewCount" type="client" />
 
 	<export function="dgsCreateButton" type="client" />
 

--- a/meta.xml
+++ b/meta.xml
@@ -289,6 +289,7 @@
 	<export function="dgsComboBoxGetEditEnabled" type="client" />
 	<export function="dgsComboBoxGetText" type="client" />
 	<export function="dgsComboBoxGetItemCount" type="client" />
+	<export function="dgsComboBoxAdjustBoxHeight" type="client" />
 
 	<export function="dgsCreateButton" type="client" />
 


### PR DESCRIPTION
This function adjusts the Combobox drop-down box height based on the given items count

Syntax:
```lua
dgsComboBoxAdjustBoxHeight ( element comboBox, [ number itemsCount ] )
```
- **ComboBox**: the combobox you want to adjust it
- **itemsCount**: how many items will be shown on the drop-down box? if this argument `nil ` the function will use the current items count

Example:
```lua
local combo = dgsCreateComboBox (200,30,200,30,"Text")
for i=1,35 do
	dgsComboBoxAddItem(combo,"# - "..tostring(i))
end
dgsComboBoxAdjustBoxHeight(combo,5) -- we can see 5 items on the drop-box now
```

screenshots:
3
![image](https://user-images.githubusercontent.com/30420446/89953953-cb946200-dc38-11ea-8c47-98ca0f327f8a.png)
8
![image](https://user-images.githubusercontent.com/30420446/89953997-e666d680-dc38-11ea-81ad-f6917c62ee33.png)
32
![image](https://user-images.githubusercontent.com/30420446/89954055-04343b80-dc39-11ea-9046-07bf762e4931.png)

