### PR TITLE
Remove getClientIP from aclrequest

### DIFF
--- a/meta.xml
+++ b/meta.xml
@@ -668,7 +668,6 @@
 	<min_mta_version server="1.5.4-9.11342" client="1.5.7-9.20157" />
 	<aclrequest>
 		<right name="function.fetchRemote" access="true" />
-		<right name="function.getClientIP" access="true" />
 		<right name="general.ModifyOtherObjects" access="true" />
 	</aclrequest>
 	<download_priority_group>999</download_priority_group>


### PR DESCRIPTION
it's already enabled by default 
https://github.com/multitheftauto/mtasa-blue/blob/6efde5d2ad68404012697488af165720d2a4ee7d/Server/mods/deathmatch/acl.xml#L51