### PR TITLE
Fixed the issue with dgsMediaStop is not working

### DIFF
--- a/html/media.html
+++ b/html/media.html
@@ -51,8 +51,10 @@
 			function stopMedia(){
 				var element = document.getElementById("element");
 				if(element!=null){
-					if(element.stop)
-						element.stop()
+					//if(element.stop)
+					//element.stop()
+					element.pause()
+					element.currentTime = 0
 				}
 			}
 			function playMedia(){


### PR DESCRIPTION
Since there is no stop method provided by the video/audio elements some other workaround can be applied to address this issue.
this pull request implements the fix from the Mozilla official documentation which can be found below:
![image](https://user-images.githubusercontent.com/2988235/131221311-59234a25-1169-412b-bebc-bb9a35c23c96.png)
[Reference](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Video_and_audio_APIs)