### PR TITLE
Updated <min_mta_version> to proper value

### DIFF
--- a/meta.xml
+++ b/meta.xml
@@ -875,7 +875,7 @@
 	<export function="dgsImportOOPClass" type="client" />
 	<export function="dgsG2DLoadHooker" type="client" />
 
-	<min_mta_version client="1.5.8-9.20998" server="1.5.4-9.11342" />
+	<min_mta_version client="1.5.8-9.20998" server="1.5.8-9.20809" />
 	<aclrequest>
 		<right name="function.fetchRemote" access="true" />
 		<right name="general.ModifyOtherObjects" access="true" />


### PR DESCRIPTION
I've updated <min_mta_version> section to a proper value, as expected due to:
> WARNING: dgs <min_mta_version> section in the meta.xml is incorrect or missing (expected at least server 1.5.8-9.20809 because of 'onResourceLoadStateChange')
WARNING: dgs requires upgrade as <min_mta_version> section in the meta.xml is incorrect or missing (expected at least server 1.5.8-9.20809 because of 'onResourceLoadStateChange')

It's just a minor thing, but I'd appreciate if you could pay attention to updating correct value for <min_mta_version> section, when making changes that affect this. I don't really like seeing unnecessary warnings as I have a tool that monitors warnings and errors, which triggers a report everytime I update dgs.