### PR TITLE
Fix two animation bugs

### DIFF
--- a/animation.lua
+++ b/animation.lua
@@ -246,7 +246,7 @@ function onAnimQueueProcess()
 				animIndex = animIndex+1
 			end
 		else
-			table.remove(animItem,animIndex)
+			table.remove(animQueue,animIndex)
 		end
 	end
 end

--- a/client.lua
+++ b/client.lua
@@ -1632,7 +1632,7 @@ dgsRegisterFastEvent("onDgsDestroy","DGSDestroy")
 
 function dgsCleanElement(source)
 	local isAlive = isElement(source)
-	local dgsType = dgsElementType[source]
+	local dgsType = dgsIsType(source)
 	if dgsType then
 		local eleData = dgsElementData[source] or {}
 		if isAlive then


### PR DESCRIPTION
I have found two minor issues (as discussed on Discord) in relation to animations / cleanup of DGS elements

1. When `isElement` returns `false` for an element inside the `onAnimQueueProcess`, the item does not get removed from the `animQueue`table but the index is removed from `animItem` instead. I think this is a typo and can cause an infinite loop because of the second minor bug I have fixed in this pull request (because normally this piece of code should not be reached, DGS should already have cleaned up the animation in the first place).

3. `dgsCleanElement` (called by the `onClientElementDestroy` event) does not work for plugin elements (such as dgs-dxroundrectangle) because the `dgsElementType` table is used directly to determine the element type, while plugins should actually use the `dgsPluginType` table instead. I have fixed this by calling the `dgsIsType` function as that one is able to correctly return the element type for non-plugin and plugin DGS elements.