### PR TITLE
Minor fixes for Gridlist

### DIFF
--- a/Core/gridlist.lua
+++ b/Core/gridlist.lua
@@ -96,6 +96,7 @@ local loadstring = loadstring
 --Dx Functions
 local dxDrawImage = dxDrawImage
 local dgsDrawText = dgsDrawText
+local dxDrawRectangle = dxDrawRectangle
 local dxSetRenderTarget = dxSetRenderTarget
 local dxGetTextWidth = dxGetTextWidth
 local dxSetBlendMode = dxSetBlendMode
@@ -2935,7 +2936,6 @@ dgsRenderer["dgs-dxgridlist"] = function(source,x,y,w,h,mx,my,cx,cy,enabledInher
 	end
 	if eleData.rowRT then
 		dxSetRenderTarget(eleData.rowRT,true)
-		dxSetBlendMode("blend")
 		if cPosStart and cPosEnd then
 			for i=eleData.FromTo[1],eleData.FromTo[2] do
 				if not elementBuffer[i] then elementBuffer[i] = {} end
@@ -3032,7 +3032,7 @@ dgsRenderer["dgs-dxgridlist"] = function(source,x,y,w,h,mx,my,cx,cy,enabledInher
 							dxDrawImageSection(_bgX,_y,backgroundWidth,rowHeight,materialWidth*_bgX/viewWidth,0,materialWidth*backgroundWidth/viewWidth,materialHeight,itemUsingBGImage,0,0,0,itemUsingBGColor)--_RowHeight
 						end
 					else
-						dxDrawImage(_bgX,_y,backgroundWidth,rowHeight,itemUsingBGImage,0,0,0,itemUsingBGColor)--_RowHeight
+						dxDrawRectangle(_bgX,_y,backgroundWidth,rowHeight,itemUsingBGColor)--_RowHeight
 					end
 					elementBuffer[i][id] = elementBuffer[i][id] or {}
 					local eBuffer = elementBuffer[i][id]

--- a/Core/gridlist.lua
+++ b/Core/gridlist.lua
@@ -96,7 +96,6 @@ local loadstring = loadstring
 --Dx Functions
 local dxDrawImage = dxDrawImage
 local dgsDrawText = dgsDrawText
-local dxDrawRectangle = dxDrawRectangle
 local dxSetRenderTarget = dxSetRenderTarget
 local dxGetTextWidth = dxGetTextWidth
 local dxSetBlendMode = dxSetBlendMode
@@ -3032,7 +3031,7 @@ dgsRenderer["dgs-dxgridlist"] = function(source,x,y,w,h,mx,my,cx,cy,enabledInher
 							dxDrawImageSection(_bgX,_y,backgroundWidth,rowHeight,materialWidth*_bgX/viewWidth,0,materialWidth*backgroundWidth/viewWidth,materialHeight,itemUsingBGImage,0,0,0,itemUsingBGColor)--_RowHeight
 						end
 					else
-						dxDrawRectangle(_bgX,_y,backgroundWidth,rowHeight,itemUsingBGColor)--_RowHeight
+						dxDrawImage(_bgX,_y,backgroundWidth,rowHeight,itemUsingBGImage,0,0,0,itemUsingBGColor)--_RowHeight
 					end
 					elementBuffer[i][id] = elementBuffer[i][id] or {}
 					local eBuffer = elementBuffer[i][id]

--- a/Core/gridlist.lua
+++ b/Core/gridlist.lua
@@ -3047,7 +3047,7 @@ dgsRenderer["dgs-dxgridlist"] = function(source,x,y,w,h,mx,my,cx,cy,enabledInher
 							local imagey = _y+(imageData[7] and imageData[4]*rowHeight or imageData[4])--_RowHeight
 							local imagew = imageData[7] and imageData[5]*columnWidth or imageData[5]
 							local imageh = imageData[7] and imageData[6]*rowHeight or imageData[6]--_RowHeight
-							dxDrawImage(imagex,imagey,imagew,imageh,imageData[1],0,0,0,imageData[2])
+							dxDrawImage(imagex,imagey,imagew,imageh,imageData[1],0,0,0,applyColorAlpha(imageData[2],parentAlpha))
 						end
 						local textXS,textYS,textXE,textYE = _x+columnOffset,_y,_sx,_sy
 						if cItem[glItem_textOffset] then


### PR DESCRIPTION
I have found two minor issues when using Gridlist:

- Semi-transparent background colors (such as `tocolor(0, 132, 255, 12)`) were not showing up because of the "blend" blend mode that was used inside the render target. This has been changed to "modulate_add" instead as recommended by the MTA Wiki (and also renders correctly now). While I was at it, I also moved from `dxDrawImage` to `dxDrawRectangle` in case no background image is set since that seems to make more sense.
- Images set by using `dgsGridListSetItemImage` were not taking the parent (gridlist) alpha correclty into account.