### PR TITLE
Add mouseButtons property

### DIFF
--- a/Core/button.lua
+++ b/Core/button.lua
@@ -96,7 +96,6 @@ function dgsCreateButton(...)
 	dgsElementData[button] = {
 		alignment = {"center","center"},
 		clickOffset = {0,0},
-		clickType = 1;	--1:LMB;2:Wheel;3:RM,
 		clip = nil,
 		colorTransitionPeriod = 0, --ms
 		color = {normalColor, hoveringColor, clickedColor},
@@ -231,18 +230,13 @@ dgsRenderer["dgs-dxbutton"] = function(source,x,y,w,h,mx,my,cx,cy,enabledInherit
 	local buttonState = 1
 	if MouseData.entered == source then
 		buttonState = 2
-		if eleData.clickType == 1 then
-			if MouseData.click.left == source then
-				buttonState = 3
-			end
-		elseif eleData.clickType == 2 then
-			if MouseData.click.right == source then
-				buttonState = 3
-			end
-		else
-			if MouseData.click.left == source or MouseData.click.right == source then
-				buttonState = 3
-			end
+		local mouseButtons = eleData.mouseButtons
+		local canLeftClick,canRightClick,canMiddleClick = true
+		if mouseButtons then
+			canLeftClick,canRightClick,canMiddleClick = mouseButtons[1],mouseButtons[2],mouseButtons[3]
+		end		
+		if (canLeftClick and MouseData.click.left == source) or (canRightClick and MouseData.click.right == source) or (canMiddleClick and MouseData.click.middle == source) then
+			buttonState = 3
 		end
 	end
 	if eleData.lastState ~= buttonState then

--- a/Core/checkbox.lua
+++ b/Core/checkbox.lua
@@ -311,18 +311,13 @@ dgsRenderer["dgs-dxcheckbox"] = function(source,x,y,w,h,mx,my,cx,cy,enabledInher
 	local colorimgid = 1
 	if MouseData.entered == source then
 		colorimgid = 2
-		if eleData.clickType == 1 then
-			if MouseData.click.left == source then
-				colorimgid = 3
-			end
-		elseif eleData.clickType == 2 then
-			if MouseData.click.right == source then
-				colorimgid = 3
-			end
-		else
-			if MouseData.click.left == source or MouseData.click.right == source then
-				colorimgid = 3
-			end
+		local mouseButtons = eleData.mouseButtons
+		local canLeftClick,canRightClick,canMiddleClick = true
+		if mouseButtons then
+			canLeftClick,canRightClick,canMiddleClick = mouseButtons[1],mouseButtons[2],mouseButtons[3]
+		end		
+		if (canLeftClick and MouseData.click.left == source) or (canRightClick and MouseData.click.right == source) or (canMiddleClick and MouseData.click.middle == source) then
+			colorimgid = 3
 		end
 	end
 	local finalcolor

--- a/Core/combobox.lua
+++ b/Core/combobox.lua
@@ -913,18 +913,13 @@ dgsRenderer["dgs-dxcombobox"] = function(source,x,y,w,h,mx,my,cx,cy,enabledInher
 	local buttonLen = textBox and (eleData.buttonLen[2] and eleData.buttonLen[1]*h or eleData.buttonLen[1]) or w
 	if MouseData.entered == source then
 		selectState = 2
-		if eleData.clickType == 1 then
-			if MouseData.click.left == source then
-				selectState = 3
-			end
-		elseif eleData.clickType == 2 then
-			if MouseData.click.right == source then
-				selectState = 3
-			end
-		else
-			if MouseData.click.left == source or MouseData.click.right == source then
-				selectState = 3
-			end
+		local mouseButtons = eleData.mouseButtons
+		local canLeftClick,canRightClick,canMiddleClick = true
+		if mouseButtons then
+			canLeftClick,canRightClick,canMiddleClick = mouseButtons[1],mouseButtons[2],mouseButtons[3]
+		end		
+		if (canLeftClick and MouseData.click.left == source) or (canRightClick and MouseData.click.right == source) or (canMiddleClick and MouseData.click.middle == source) then
+			selectState = 3
 		end
 	end
 	local finalcolor

--- a/Core/edit.lua
+++ b/Core/edit.lua
@@ -231,25 +231,34 @@ end
 
 function dgsEditCheckMultiClick(button,state,x,y,times)
 	if state == "down" then
+		local mouseButtons = dgsElementData[source].mouseButtons
+		local mouseClicked
+		if mouseButtons then
+			if button == "left" then
+				mouseClicked = mouseButtons[1]
+			elseif button == "middle" then
+				mouseClicked = mouseButtons[2]
+			elseif button == "right" then
+				mouseClicked = mouseButtons[3]
+			end
+		else
+			mouseClicked = button == "left"
+		end
+		if not mouseClicked then return end
+
 		if times== 1 then
-			if button ~= "middle" then
-				local shift = getKeyState("lshift") or getKeyState("rshift")
-				local pos,side = searchEditMousePosition(source,x)
-				dgsEditSetCaretPosition(source,pos,shift)
-			end
+			local shift = getKeyState("lshift") or getKeyState("rshift")
+			local pos,side = searchEditMousePosition(source,x)
+			dgsEditSetCaretPosition(source,pos,shift)
 		elseif times == 2 then
-			if button == "left" then
-				local pos,side = searchEditMousePosition(source,x)
-				local text = dgsElementData[source].text
-				local s,e = dgsSearchFullWordType(text,pos,side)
-				dgsEditSetCaretPosition(source,s)
-				dgsEditSetCaretPosition(source,e,true)
-			end
+			local pos,side = searchEditMousePosition(source,x)
+			local text = dgsElementData[source].text
+			local s,e = dgsSearchFullWordType(text,pos,side)
+			dgsEditSetCaretPosition(source,s)
+			dgsEditSetCaretPosition(source,e,true)
 		elseif times == 3 then
-			if button == "left" then
-				dgsEditSetCaretPosition(source,_)
-				dgsEditSetCaretPosition(source,0,true)
-			end
+			dgsEditSetCaretPosition(source,_)
+			dgsEditSetCaretPosition(source,0,true)
 		end
 	end
 end
@@ -640,10 +649,18 @@ function configEdit(edit)
 end
 
 function resetEdit(x,y)
-	if dgsGetType(MouseData.focused) == "dgs-dxedit" then
-		if MouseData.focused == MouseData.click.left then
-			local pos = searchEditMousePosition(MouseData.focused,MouseData.cursorPos[1] or x*sW)
-			dgsEditSetCaretPosition(MouseData.focused,pos,true)
+	local dgsEdit = MouseData.focused
+	if dgsGetType(dgsEdit) == "dgs-dxedit" then
+		local mouseButtons = dgsElementData[dgsEdit].mouseButtons
+		local clickedEle 
+		if mouseButtons and not mouseButtons[1] then 
+			clickedEle = (mouseButtons[2] and MouseData.click.right) or (mouseButtons[3] and MouseData.click.middle)
+		else 
+			clickedEle = MouseData.click.left
+		end
+		if dgsEdit == clickedEle then
+			local pos = searchEditMousePosition(dgsEdit,MouseData.cursorPos[1] or x*sW)
+			dgsEditSetCaretPosition(dgsEdit,pos,true)
 		end
 	end
 end

--- a/Core/gridlist.lua
+++ b/Core/gridlist.lua
@@ -24,7 +24,6 @@ dgsRegisterProperties('dgs-dxgridlist',{
 	font = 					{	PArg.Font+PArg.String	},
 	leading = 				{	PArg.Number	},
 	multiSelection = 		{	PArg.Bool	},
-	mouseSelectButton = 	{	{ PArg.Bool, PArg.Bool, PArg.Bool }	},
 	moveHardness = 			{	{ PArg.Number, PArg.Number }	},
 	rowColorTemplate =		{	PArg.Table },
 	rowColor = 				{	{ PArg.Color, PArg.Color,PArg.Color }	},
@@ -125,11 +124,6 @@ local tableRemoveItemFromArray = table.removeItemFromArray
 local utf8Len = utf8.len
 gridlistSortFunctions = {}
 self = false
-mouseButtonOrder = {
-	left=1,
-	middle=2,
-	right=3,
-}
 --[[
 Selection Mode
 1-> Row Selection
@@ -213,7 +207,6 @@ function dgsCreateGridList(...)
 		itemClick = {},
 		lastSelectedItem = {1,1},
 		leading = 0,
-		mouseSelectButton = {true,false,false},
 		moveHardness = {0.1,0.9},
 		moveType = 0,	--0 for wheel, 1 For scroll bar
 		multiSelection = false,

--- a/Core/memo.lua
+++ b/Core/memo.lua
@@ -259,35 +259,43 @@ end
 
 function dgsMemoMultiClickCheck(button,state,x,y,times)
 	if state == "down" then
-		local pos,line,side = searchMemoMousePosition(source,x,y)
-		eleData = dgsElementData[source]
-		if button == "left" then
-			if not eleData.multiClickCounter[1] then
-				eleData.multiClickCounter = {pos,line,times-1}
-			elseif eleData.multiClickCounter[1] ~= pos or eleData.multiClickCounter[2] ~= line then
-				eleData.multiClickCounter = {pos,line,times-1}
+		local eleData = dgsElementData[source]
+		local mouseButtons = eleData.mouseButtons
+		local mouseClicked
+		if mouseButtons then
+			if button == "left" then
+				mouseClicked = mouseButtons[1]
+			elseif button == "middle" then
+				mouseClicked = mouseButtons[2]
+			elseif button == "right" then
+				mouseClicked = mouseButtons[3]
 			end
+		else
+			mouseClicked = button == "left"
 		end
+		if not mouseClicked then return end
+		
+		local pos,line,side = searchMemoMousePosition(source,x,y)
+		if not eleData.multiClickCounter[1] then
+			eleData.multiClickCounter = {pos,line,times-1}
+		elseif eleData.multiClickCounter[1] ~= pos or eleData.multiClickCounter[2] ~= line then
+			eleData.multiClickCounter = {pos,line,times-1}
+		end
+		
 		local t = times-eleData.multiClickCounter[3]
 		if t == 1 then
-			if button ~= "middle" then
-				local shift = getKeyState("lshift") or getKeyState("rshift")
-				dgsMemoSetCaretPosition(source,pos,line,shift)
-			end
+			local shift = getKeyState("lshift") or getKeyState("rshift")
+			dgsMemoSetCaretPosition(source,pos,line,shift)
 		elseif t == 2 then
-			if button == "left" then
-				local textTable = dgsElementData[source].text
-				local text = textTable[line][0]
-				local s,e = dgsSearchFullWordType(text,pos,side)
-				dgsMemoSetCaretPosition(source,s,line)
-				dgsMemoSetCaretPosition(source,e,line,true)
-			end
+			local textTable = dgsElementData[source].text
+			local text = textTable[line][0]
+			local s,e = dgsSearchFullWordType(text,pos,side)
+			dgsMemoSetCaretPosition(source,s,line)
+			dgsMemoSetCaretPosition(source,e,line,true)
 		elseif t == 3 then
-			if button == "left" then
-				dgsMemoSetCaretPosition(source,_,line)
-				dgsMemoMoveCaret(source,1,0)
-				dgsMemoSetCaretPosition(source,0,line,true)
-			end
+			dgsMemoSetCaretPosition(source,_,line)
+			dgsMemoMoveCaret(source,1,0)
+			dgsMemoSetCaretPosition(source,0,line,true)
 		end
 	end
 end
@@ -583,10 +591,18 @@ function dgsMemoGetReadOnly(memo)
 end
 
 function resetMemo(x,y)
-	if dgsGetType(MouseData.focused) == "dgs-dxmemo" then
-		if MouseData.focused == MouseData.click.left then
-			local pos,line = searchMemoMousePosition(MouseData.focused,MouseData.cursorPos[1] or x*sW, MouseData.cursorPos[2] or y*sH)
-			dgsMemoSetCaretPosition(MouseData.focused,pos,line,true)
+	local dgsMemo = MouseData.focused
+	if dgsGetType(dgsMemo) == "dgs-dxmemo" then
+		local mouseButtons = dgsElementData[dgsMemo].mouseButtons
+		local clickedEle 
+		if mouseButtons and not mouseButtons[1] then 
+			clickedEle = (mouseButtons[2] and MouseData.click.right) or (mouseButtons[3] and MouseData.click.middle)
+		else 
+			clickedEle = MouseData.click.left
+		end
+		if dgsMemo == clickedEle then
+			local pos,line = searchMemoMousePosition(dgsMemo,MouseData.cursorPos[1] or x*sW, MouseData.cursorPos[2] or y*sH)
+			dgsMemoSetCaretPosition(dgsMemo,pos,line,true)
 		end
 	end
 end

--- a/Core/radiobutton.lua
+++ b/Core/radiobutton.lua
@@ -297,18 +297,13 @@ dgsRenderer["dgs-dxradiobutton"] = function(source,x,y,w,h,mx,my,cx,cy,enabledIn
 	local colorimgid = 1
 	if MouseData.entered == source then
 		colorimgid = 2
-		if eleData.clickType == 1 then
-			if MouseData.click.left == source then
-				colorimgid = 3
-			end
-		elseif eleData.clickType == 2 then
-			if MouseData.click.right == source then
-				colorimgid = 3
-			end
-		else
-			if MouseData.click.left == source or MouseData.click.right == source then
-				colorimgid = 3
-			end
+		local mouseButtons = eleData.mouseButtons 
+		local canLeftClick,canRightClick,canMiddleClick = true 
+		if mouseButtons then 
+			canLeftClick,canRightClick,canMiddleClick = mouseButtons[1],mouseButtons[2],mouseButtons[3]
+		end
+		if (MouseData.click.left == source and canLeftClick) or (MouseData.click.right == source and canRightClick) or (MouseData.click.middle == source and canMiddleClick) then
+			colorimgid = 3
 		end
 	end
 	local finalcolor

--- a/Core/scrollbar.lua
+++ b/Core/scrollbar.lua
@@ -494,7 +494,12 @@ dgsRenderer["dgs-dxscrollbar"] = function(source,x,y,w,h,mx,my,cx,cy,enabledInhe
 				colorImageIndex[MouseData.scbEnterData] = 2
 			end
 		else
-			if MouseData.click.left == source then
+			local mouseButtons = eleData.mouseButtons
+			local canLeftClick,canRightClick,canMiddleClick = true
+			if mouseButtons then
+				canLeftClick,canRightClick,canMiddleClick = mouseButtons[1],mouseButtons[2],mouseButtons[3]
+			end		
+			if (canLeftClick and MouseData.click.left == source) or (canRightClick and MouseData.click.right == source) or (canMiddleClick and MouseData.click.middle == source) then
 				colorImageIndex[MouseData.scbClickData] = 3
 				if MouseData.scbClickData == 3 then
 					local scrollPosition = 0

--- a/Core/selector.lua
+++ b/Core/selector.lua
@@ -471,7 +471,12 @@ dgsRenderer["dgs-dxselector"] = function(source,x,y,w,h,mx,my,cx,cy,enabledInher
 				selectorTextColors[preEnterData] = 2
 			end
 		else
-			if MouseData.click.left == source then
+			local mouseButtons = eleData.mouseButtons
+			local canLeftClick,canRightClick,canMiddleClick = true
+			if mouseButtons then
+				canLeftClick,canRightClick,canMiddleClick = mouseButtons[1],mouseButtons[2],mouseButtons[3]
+			end		
+			if (canLeftClick and MouseData.click.left == source) or (canRightClick and MouseData.click.right == source) or (canMiddleClick and MouseData.click.middle == source) then
 				selectorTextColors[MouseData.selectorClickData] = 3
 			else
 				selectorTextColors[MouseData.selectorClickData] = 2

--- a/Core/switchbutton.lua
+++ b/Core/switchbutton.lua
@@ -249,13 +249,12 @@ dgsRenderer["dgs-dxswitchbutton"] = function(source,x,y,w,h,mx,my,cx,cy,enabledI
 		if isHitCursor then
 			colorImgID = 2
 		end
-		if eleData.clickType == 1 and MouseData.click.left == source then
-			colorImgBgID = 3
-			colorImgID = isHitCursor and 3 or colorImgID
-		elseif eleData.clickType == 2 and MouseData.click.right == source then
-			colorImgBgID = 3
-			colorImgID = isHitCursor and 3 or colorImgID
-		elseif MouseData.click.left == source or MouseData.click.right == source then
+		local mouseButtons = eleData.mouseButtons
+		local canLeftClick,canRightClick,canMiddleClick = true
+		if mouseButtons then
+			canLeftClick,canRightClick,canMiddleClick = mouseButtons[1],mouseButtons[2],mouseButtons[3]
+		end		
+		if (canLeftClick and MouseData.click.left == source) or (canRightClick and MouseData.click.right == source) or (canMiddleClick and MouseData.click.middle == source) then
 			colorImgBgID = 3
 			colorImgID = isHitCursor and 3 or colorImgID
 		end

--- a/Core/switchbutton.lua
+++ b/Core/switchbutton.lua
@@ -119,7 +119,6 @@ function dgsCreateSwitchButton(...)
 		cursorWidth = style.cursorWidth,
 		troughWidth = style.troughWidth,
 		stateAnim = state and 1 or -1,
-		clickButton = "left"; --"left":LMB;"middle":Wheel;"right":RM,
 		clickState = "up"; --"down":Down;"up":U,
 		cursorLength = style.cursorLength,
 		clip = false,

--- a/client.lua
+++ b/client.lua
@@ -1948,6 +1948,13 @@ addEventHandler("onClientClick",root,function(button,state,x,y)
 		if not isElement(dgsEle) then return end
 		if wasEventCancelled() then return end
 
+		local mouseButtons = eleData.mouseButtons
+		local canLeftClick,canRightClick,canMiddleClick = true
+		if mouseButtons then
+			canLeftClick,canRightClick,canMiddleClick = mouseButtons[1],mouseButtons[2],mouseButtons[3]
+		end		
+		local mouseClicked = (button == "left" and canLeftClick) or (button == "right" and canRightClick) or (button == "middle" and canMiddleClick)
+
 		local guitype = dgsGetType(dgsEle)
 		if guitype == "dgs-dxbrowser" then
 			focusBrowser(dgsEle)
@@ -1956,7 +1963,7 @@ addEventHandler("onClientClick",root,function(button,state,x,y)
 		end
 		local parent = dgsGetParent(dgsEle)
 		if guitype == "dgs-dxswitchbutton" then
-			if eleData.clickState == state and eleData.clickButton == button then
+			if eleData.clickState == state and mouseClicked then
 				dgsSetData(dgsEle,"state", not eleData.state)
 			end
 		end
@@ -1967,12 +1974,7 @@ addEventHandler("onClientClick",root,function(button,state,x,y)
 				dgsBringToFront(scrollbar[1],_,_,true)
 				dgsBringToFront(scrollbar[2],_,_,true)
 			end
-			local mouseButtons = eleData.mouseButtons
-			local canLeftClick,canRightClick,canMiddleClick = true
-			if mouseButtons then
-				canLeftClick,canRightClick,canMiddleClick = mouseButtons[1],mouseButtons[2],mouseButtons[3]
-			end		
-			if button == "left" then
+			if mouseClicked then
 				if not checkScale(dgsEle) then
 					checkMove(dgsEle)
 				end
@@ -2020,15 +2022,15 @@ addEventHandler("onClientClick",root,function(button,state,x,y)
 				elseif guitype == "dgs-dxcombobox" then
 					dgsSetData(dgsEle,"listState",eleData.listState == 1 and -1 or 1)
 				--elseif guitype == "dgs-dxselector" then
-
 				end
-			elseif button == "middle" then
+			end
+			if button == "middle" then
 				if dgsGetType(MouseData.topScrollable) == "dgs-dxscalepane" then
 					dgsScalePaneCheckMove(MouseData.topScrollable)
 				end
 			end
 			if guitype == "dgs-dxgridlist" then
-				if (button == "left" and canLeftClick) or (button == "right" and canRightClick) or (button == "middle" and canRightClick)  then
+				if mouseClicked then
 					local oPreSelect = eleData.oPreSelect
 					local rowData = eleData.rowData
 					----Sort

--- a/client.lua
+++ b/client.lua
@@ -1974,10 +1974,12 @@ addEventHandler("onClientClick",root,function(button,state,x,y)
 				dgsBringToFront(scrollbar[1],_,_,true)
 				dgsBringToFront(scrollbar[2],_,_,true)
 			end
-			if mouseClicked then
+			if button == "left" then 
 				if not checkScale(dgsEle) then
 					checkMove(dgsEle)
 				end
+			end
+			if mouseClicked then
 				if guitype == "dgs-dxscrollbar" then
 					local scrollArrow = eleData.scrollArrow
 					local x,y = dgsGetPosition(dgsEle,false,true)

--- a/client.lua
+++ b/client.lua
@@ -1974,7 +1974,7 @@ addEventHandler("onClientClick",root,function(button,state,x,y)
 				dgsBringToFront(scrollbar[1],_,_,true)
 				dgsBringToFront(scrollbar[2],_,_,true)
 			end
-			if button == "left" then 
+			if button == "left" then
 				if not checkScale(dgsEle) then
 					checkMove(dgsEle)
 				end

--- a/client.lua
+++ b/client.lua
@@ -1279,14 +1279,15 @@ function dgsCheckHit(hits,cursorShowing)
 	end
 	if clickedElement then
 		if MouseData.lastPos[1] ~= mx or MouseData.lastPos[2] ~= my then
-			dgsTriggerEvent("onDgsMouseDrag",MouseData.click.left,mx,my)
-			if not dgsDragDropBoard.lock and MouseData.clickPosition.left[0] then
-				if ((MouseData.clickPosition.left[1]-mx)^2+(MouseData.clickPosition.left[2]-my)^2)^0.5 > 10 then
+			dgsTriggerEvent("onDgsMouseDrag",clickedElement,mx,my)
+			if not dgsDragDropBoard.lock and MouseData.clickPosition[clickedButton][0] then
+				if ((MouseData.clickPosition[clickedButton][1]-mx)^2+(MouseData.clickPosition[clickedButton][2]-my)^2)^0.5 > 10 then
 					dgsDragDropBoard.lock = true
-					dgsTriggerEvent("onDgsDrag",MouseData.click.left)
+					dgsDragDropBoard.button = clickedButton
+					dgsTriggerEvent("onDgsDrag",clickedElement)
 					if not wasEventCancelled() then
-						if dgsElementData[MouseData.click.left].dragHandler then
-							dgsSendDragNDropData(unpack(dgsElementData[MouseData.click.left].dragHandler))
+						if dgsElementData[clickedElement].dragHandler then
+							dgsSendDragNDropData(unpack(dgsElementData[clickedElement].dragHandler))
 						end
 					end
 				end
@@ -2259,19 +2260,17 @@ addEventHandler("onClientClick",root,function(button,state,x,y)
 		end
 		if button == MouseData.scbClickButton then 
 			MouseData.MoveScroll[0] = false
-			if dgsDragDropBoard[0] then
-				local data = dgsRetrieveDragNDropData()
-				if isElement(dgsEle) then
-					dgsTriggerEvent("onDgsDrop",dgsEle,data)
-				end
-			end
-		dgsDragDropBoard.button = nil
-			dgsDragDropBoard.lock = false
-		elseif button == "right" then
-			MouseData.click.right = false
-		else 
-			MouseData.click.middle = false
 		end
+		if dgsDragDropBoard[0] and button == dgsDragDropBoard.button then 
+			local data = dgsRetrieveDragNDropData()
+			if isElement(dgsEle) then
+				dgsTriggerEvent("onDgsDrop",dgsEle,data)
+			end
+		end
+		dgsDragDropBoard.button = nil
+		dgsDragDropBoard.lock = false
+
+
 		MouseData.Move[0] = false
 		MouseData.MoveScale[0] = false
 		MouseData.Scale[0] = false

--- a/client.lua
+++ b/client.lua
@@ -1967,6 +1967,11 @@ addEventHandler("onClientClick",root,function(button,state,x,y)
 				dgsBringToFront(scrollbar[1],_,_,true)
 				dgsBringToFront(scrollbar[2],_,_,true)
 			end
+			local mouseButtons = eleData.mouseButtons
+			local canLeftClick,canRightClick,canMiddleClick = true
+			if mouseButtons then
+				canLeftClick,canRightClick,canMiddleClick = mouseButtons[1],mouseButtons[2],mouseButtons[3]
+			end		
 			if button == "left" then
 				if not checkScale(dgsEle) then
 					checkMove(dgsEle)
@@ -2023,9 +2028,7 @@ addEventHandler("onClientClick",root,function(button,state,x,y)
 				end
 			end
 			if guitype == "dgs-dxgridlist" then
-				local clickButton = eleData.mouseSelectButton
-				local isSelectButtonEnabled = clickButton[mouseButtonOrder[button]]
-				if isSelectButtonEnabled then
+				if (button == "left" and canLeftClick) or (button == "right" and canRightClick) or (button == "middle" and canRightClick)  then
 					local oPreSelect = eleData.oPreSelect
 					local rowData = eleData.rowData
 					----Sort

--- a/client.lua
+++ b/client.lua
@@ -2272,6 +2272,7 @@ addEventHandler("onClientClick",root,function(button,state,x,y)
 
 
 		MouseData.Move[0] = false
+		MouseData.Move[3] = nil
 		MouseData.MoveScale[0] = false
 		MouseData.Scale[0] = false
 		MouseData.scbClickData = nil

--- a/client.lua
+++ b/client.lua
@@ -1563,12 +1563,15 @@ function onClientMouseTriggered()
 end
 
 MouseHolder = {}
-MouseKeyConverter = {left="mouse1",right="mouse2",middle="mouse3"}
-MouseKeySupports = {["dgs-dxscrollbar"] = true,["dgs-dxselector"] = true}
 function onDGSMouseCheck(source,button,state)
-	local button = MouseKeyConverter[button]
+	local eleData = dgsElementData[source]
+	local mouseButtons = eleData.mouseButtons
+	local canLeftClick,canRightClick,canMiddleClick = true
+	if mouseButtons then
+		canLeftClick,canRightClick,canMiddleClick = mouseButtons[1],mouseButtons[2],mouseButtons[3]
+	end	
 	if state == "down" then
-		if MouseKeySupports[dgsGetType(source)] then
+		if (button == "left" and canLeftClick) or (button == "right" and canRightClick) or (button == "middle" and canMiddleClick) then
 			if not MouseHolder.lastKey then
 				if isTimer(MouseHolder.Timer) then killTimer(MouseHolder.Timer) end
 				MouseHolder = {

--- a/dgsExportedFunction.lua
+++ b/dgsExportedFunction.lua
@@ -382,12 +382,24 @@ function dgsG2DLoadHooker(isLocal)
 			return dgsGridListSetItemColor(gl,row,column,...)
 		end
 		guiGridListSetSelectedItem = function(gl,row,column,...)
-			if column and dgsGridListGetColumnCount(gl) < column then return false end
-			if row and row ~= -1 then
-				row = isGUIGridList[gl] and row+1 or row
-			end
-			if row and dgsGridListGetRowCount(gl) < row then return false end
-			return dgsGridListSetSelectedItem(gl,row,column,...)
+    		if column then 
+        		if column <= 0 then 
+            		column = -1
+        		elseif dgsGridListGetColumnCount(gl) < column then 
+            		return false 
+        		end
+    		end
+    		if row then 
+        		if row <= -1 then 
+            		row = -1
+        		elseif isGUIGridList[gl] then 
+            		row = row+1
+            		if dgsGridListGetRowCount(gl) < row then 
+                		return false 
+            		end
+       			 end
+    		end
+    		return dgsGridListSetSelectedItem(gl,row,column,...)
 		end
 		guiGridListAutoSizeColumn = function (gl,column)
 			if column and dgsGridListGetColumnCount(gl) < column then return false end

--- a/dgsExportedFunction.lua
+++ b/dgsExportedFunction.lua
@@ -67,7 +67,7 @@ function dgsImportFunction(name,nameAs)
 			function DGSCallMT:__index(fncName)
 				if type(fncName) ~= 'string' then fncName = tostring(fncName) end
 				self[fncName] = function(...)
-					if not dgsImportHead then error("DGS import data is missing or DGS is not running, please reimport dgs functions("..getResourceName(getThisResource())..")") end
+					if not dgsImportHead then return outputDebugString("[DGS] "..getResourceName(getThisResource())..": DGS import data is missing or DGS is not running, please reimport dgs functions",4,255,0,0) end
 					if isElement(dgsRoot) then
 						local isCreateFunction = fncName:sub(1,9) == "dgsCreate"
 						if isTraceDebug then

--- a/manager.lua
+++ b/manager.lua
@@ -275,6 +275,16 @@ end
 function dgsBringToFront(dgsEle,mouse,dontMoveParent,dontFocus)
 	local eleType = dgsIsType(dgsEle)
 	if not(eleType) then error(dgsGenAsrt(dgsEle,"dgsBringToFront",1,"dgs-dxelement")) end
+	if mouse then 
+		local mouseButtons = dgsElementData[dgsEle].mouseButtons
+		if mouseButtons then 
+			if (mouse == "left" and not mouseButtons[1]) 
+			or (mouse == "right" and not mouseButtons[2]) 
+			or (mouse == "middle" and not mouseButtons[3]) then
+				return 
+			end
+		end
+	end
 	local parent = dgsElementData[dgsEle].parent	--Get Parent
 	if not dontFocus then dgsFocus(dgsEle) end
 	if dgsElementData[dgsEle].changeOrder then
@@ -313,8 +323,13 @@ function dgsBringToFront(dgsEle,mouse,dontMoveParent,dontFocus)
 						tableInsert(children,parents)
 						if dgsElementType[parents] == "dgs-dxscrollpane" then
 							local scrollbar = dgsElementData[parents].scrollbars
-							dgsBringToFront(scrollbar[1],"left",_,true,false)
-							dgsBringToFront(scrollbar[2],"left",_,true,false)
+							local clickedButton = "left"
+							local mouseButtons = dgsElementData[parents].mouseButtons
+							if mouseButtons and not mouseButtons[1] then 
+								clickedButton = (mouseButtons[2] and "right") or (mouseButtons[3] and "middle") or "left"
+							end
+							dgsBringToFront(scrollbar[1],clickedButton,_,true,false)
+							dgsBringToFront(scrollbar[2],clickedButton,_,true,false)
 						end
 					end
 					parents = uparents
@@ -342,8 +357,13 @@ function dgsBringToFront(dgsEle,mouse,dontMoveParent,dontFocus)
 							tableInsert(layerTable,parents)
 							if dgsElementType[parents] == "dgs-dxscrollpane" then
 								local scrollbar = dgsElementData[parents].scrollbars
-								dgsBringToFront(scrollbar[1],"left",_,true,false)
-								dgsBringToFront(scrollbar[2],"left",_,true,false)
+								local clickedButton = "left"
+								local mouseButtons = dgsElementData[parents].mouseButtons
+								if mouseButtons and not mouseButtons[1] then 
+									clickedButton = (mouseButtons[2] and "right") or (mouseButtons[3] and "middle") or "left"
+								end
+								dgsBringToFront(scrollbar[1],clickedButton,_,true,false)
+								dgsBringToFront(scrollbar[2],clickedButton,_,true,false)
 							end
 						end
 						break


### PR DESCRIPTION
This PR introduces a new _general_ property called `mouseButtons` which will allow control over which mouse buttons elements can be clicked with. 
### Syntax
```lua
dgsSetProperty (dgsElement, "mouseButtons", {bool left, bool right, bool middle}
```
By default, left click will be enabled. 

### Breaking changes 

**1.** As a result of this new property, the following properties are no longer needed and will be removed: 
* clickType (`dgs-button`,`dgs-checkbox`, `dgs-combobox`, `dgs-radiobutton`, `dgs-switchbutton`)
* clickButton (`dgs-switchbutton`)
* mouseSelectButton (`dgs-gridlist`)

**2.** The input elements (`dgs-edit` and `dgs-memo`) were previously clickable by all mouse buttons. This PR will change the default behavior to only allow left-click, or any other button specified in the `mouseButtons` property.

**3.** Previously, the focus could be clicked using any mouse button. This PR will change the default behavior to only allow left-click, or any other button specified in the `mouseButtons` property.

### To-Do List

- [x] Button
- [x] Checkbox
- [x] Combobox
- [x] Drag and Drop
- [ ] Editbox and Memo
- [x] Gridlist
- [x] Radiobutton
- [x] Scrollbar
- [x] Selector
- [x] Switchbutton
- [x] Tabpanel
- [x] Focus

_Note to the merger: Please use [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits) to merge this PR to squash all commits into a single commit._

