### PR TITLE
Upgrade base64Decode to decodeString

### DIFF
--- a/plugin/pasteHandler/pasteHandler.lua
+++ b/plugin/pasteHandler/pasteHandler.lua
@@ -23,7 +23,7 @@ function dgsPasteHandlerSetEnabled(state)
 
 		addEventHandler("DGSI_Paste",GlobalPasteHandler,function(data,theType)
 			if theType == "file" then
-				local result = base64Decode(split(data,",")[2])
+				local result = decodeString("base64", split(data,",")[2])
 				return dgsTriggerEvent("onDgsPaste",resourceRoot,result,theType)
 			elseif theType == "string" then
 				return dgsTriggerEvent("onDgsPaste",resourceRoot,data,theType)


### PR DESCRIPTION
This change ensures future compatibility since `base64Decode` is a deprecated function.