### PR TITLE
Fix fromColor nil error in dgsMenuGetItemColor

### DIFF
--- a/Core/menu.lua
+++ b/Core/menu.lua
@@ -15,13 +15,6 @@ local dxGetPixelColor = dxGetPixelColor
 local dxSetRenderTarget = dxSetRenderTarget
 local dxGetTextWidth = dxGetTextWidth
 local dxSetBlendMode = dxSetBlendMode
-local function fromColor(color)
-	local a = math.floor(color / 16777216) % 256
-	local r = math.floor(color / 65536) % 256
-	local g = math.floor(color / 256) % 256
-	local b = color % 256
-	return r, g, b, a
-end
 --
 local dgsTriggerEvent = dgsTriggerEvent
 local createElement = createElement
@@ -71,7 +64,7 @@ function dgsCreateMenu(...)
 		itemData = {},
 		itemHeight = sStyle.itemHeight,
 		itemGap = sStyle.itemGap,
-		itemColor = {sStyle.itemColor[1],sStyle.itemColor[2]},
+		itemColor = {sStyle.itemColor[1],sStyle.itemColor[2]},	--normalColor, hoveringColor
 		itemTextColor = sStyle.itemTextColor,
 		itemTextOffset = {sStyle.itemTextOffset[1],sStyle.itemTextOffset[2]},
 		itemImage = {normalImage,hoveringImage},
@@ -263,22 +256,18 @@ function dgsMenuGetItemColor(menu,uniqueID,notSplitColor)
 	local itemMap = eleData.itemMap
 	local item = itemMap[uniqueID]
 	if not item then error(dgsGenAsrt(menu,"dgsMenuGetItemColor",2,_,_,"Invalid index '"..tostring(uniqueID).."'")) end
-	local itemColors = item[-5] or eleData.itemTextColor
-	if notSplitColor then
-		if type(itemColors) == "table" then
-			return itemColors[1],itemColors[2]
-		else
-			return itemColors,itemColors
-		end
+	local itemColor = item[-5] or eleData.itemColor
+	local itemColor1,itemColor2
+	if type(itemColors) == "table" then
+		itemColor1,itemColor2 = itemColor[1],itemColor[2]
 	else
-		local color1, color2
-		if type(itemColors) == "table" then
-			color1, color2 = itemColors[1], itemColors[2]
-		else
-			color1, color2 = itemColors, itemColors
-		end
-		local dR,dG,dB,dA = fromColor(color1)
-		local hR,hG,hB,hA = fromColor(color2)
+		itemColor1,itemColor2 = itemColor,itemColor
+	end
+	if notSplitColor then
+		return itemColor1,itemColor2
+	else
+		local dR,dG,dB,dA = fromColor(itemColor1)
+		local hR,hG,hB,hA = fromColor(itemColor2)
 		return dR,dG,dB,dA,hR,hG,hB,hA
 	end
 end

--- a/Core/menu.lua
+++ b/Core/menu.lua
@@ -15,6 +15,13 @@ local dxGetPixelColor = dxGetPixelColor
 local dxSetRenderTarget = dxSetRenderTarget
 local dxGetTextWidth = dxGetTextWidth
 local dxSetBlendMode = dxSetBlendMode
+local function fromColor(color)
+	local a = math.floor(color / 16777216) % 256
+	local r = math.floor(color / 65536) % 256
+	local g = math.floor(color / 256) % 256
+	local b = color % 256
+	return r, g, b, a
+end
 --
 local dgsTriggerEvent = dgsTriggerEvent
 local createElement = createElement
@@ -256,11 +263,22 @@ function dgsMenuGetItemColor(menu,uniqueID,notSplitColor)
 	local itemMap = eleData.itemMap
 	local item = itemMap[uniqueID]
 	if not item then error(dgsGenAsrt(menu,"dgsMenuGetItemColor",2,_,_,"Invalid index '"..tostring(uniqueID).."'")) end
+	local itemColors = item[-5] or eleData.itemTextColor
 	if notSplitColor then
-		return item[-5][1],item[-5][2]
+		if type(itemColors) == "table" then
+			return itemColors[1],itemColors[2]
+		else
+			return itemColors,itemColors
+		end
 	else
-		local dR,dG,dB,dA = fromColor(item[-5][1])
-		local hR,hG,hB,hA = fromColor(item[-5][2])
+		local color1, color2
+		if type(itemColors) == "table" then
+			color1, color2 = itemColors[1], itemColors[2]
+		else
+			color1, color2 = itemColors, itemColors
+		end
+		local dR,dG,dB,dA = fromColor(color1)
+		local hR,hG,hB,hA = fromColor(color2)
 		return dR,dG,dB,dA,hR,hG,hB,hA
 	end
 end
@@ -389,7 +407,7 @@ end
 ----------------------------------------------------------------
 dgsOnPropertyChange["dgs-dxmenu"] = {
 	visible = function(source)
-		
+
 	end,
 }
 ----------------------------------------------------------------

--- a/Core/menu.lua
+++ b/Core/menu.lua
@@ -16,6 +16,7 @@ local dxSetRenderTarget = dxSetRenderTarget
 local dxGetTextWidth = dxGetTextWidth
 local dxSetBlendMode = dxSetBlendMode
 --
+local fromColor = fromcolor
 local dgsTriggerEvent = dgsTriggerEvent
 local createElement = createElement
 local dgsSetType = dgsSetType
@@ -258,7 +259,7 @@ function dgsMenuGetItemColor(menu,uniqueID,notSplitColor)
 	if not item then error(dgsGenAsrt(menu,"dgsMenuGetItemColor",2,_,_,"Invalid index '"..tostring(uniqueID).."'")) end
 	local itemColor = item[-5] or eleData.itemColor
 	local itemColor1,itemColor2
-	if type(itemColors) == "table" then
+if type(itemColor) == "table" then
 		itemColor1,itemColor2 = itemColor[1],itemColor[2]
 	else
 		itemColor1,itemColor2 = itemColor,itemColor
@@ -298,7 +299,8 @@ function dgsMenuSetItemColor(menu,uniqueID,...)
 		local clr = tocolor(...)
 		colors = {clr,clr}
 	end
-	item[-5] = colors
+item[-5] = colors
+	local itemColors = item[-5]
 	return true
 end
 


### PR DESCRIPTION
## Description
The `dgsMenuGetItemColor` function in `dgs\Core\menu.lua` had multiple issues:
1. Calling an undefined global function `fromColor()`
2. Not handling cases where items don't have custom colors set
3. Improper error handling for nil color values

## Error Messages
```
[error] dgs\Core\menu.lua:262 - attempt to call global 'fromColor' (a nil value)
[error] dgs\Core\menu.lua:263 - attempt to call upvalue 'fromColor' (a nil value)
[error] testmemo\arabic_test_panel.lua:15 - call: failed to call 'dgs:dgsMenuGetItemColor'
```

## Example Usage
I have added three examples of how the function is used in the wiki page of [DgsMenuGetItemColor](https://wiki.multitheftauto.com/wiki/DgsMenuGetItemColor)

## Root Causes
1. **Missing fromColor function**: The `fromColor` function doesn't exist in the `dgs\Core\menu.lua` file. It should be implemented to convert color integers to RGBA components.
2. **Nil access error**: When `item[-5]` is `nil` (no custom color set), the function tries to access `nil[1]` and `nil[2]`
3. **No fallback handling**: No fallback to default menu colors when item has no custom colors

## Testing Results
- ✅ Example 1: RGBA component extraction works correctly
- ✅ Example 2: Raw color values returned correctly (negative numbers are expected)
- ✅ Example 3: Color inspection and modification works properly

## Note about Color Values
When using `notSplitColor = true`, the function returns raw color integers which may appear as negative numbers (e.g., `-16776961`, `-256`). This is normal behavior, these are packed color values in 32-bit integer format.
