### PR TITLE
Handle item height based on text presence of the seperator item

### DIFF
--- a/Core/menu.lua
+++ b/Core/menu.lua
@@ -144,7 +144,12 @@ function dgsMenuAutoResize(menu)
 		local commandOrIsSeparator = item[-3]
 		if commandOrIsSeparator == true then
 			drawPosY = drawPosY+separatorGap
-			drawPosY = drawPosY+separatorHeight
+			local text = item[-2]
+			if text == nil then
+				drawPosY = drawPosY+separatorHeight
+			else
+				drawPosY = drawPosY+itemHeight
+			end
 			drawPosY = drawPosY+separatorGap
 		else
 			drawPosY = drawPosY+itemGap
@@ -396,7 +401,7 @@ end
 ----------------------------------------------------------------
 dgsOnPropertyChange["dgs-dxmenu"] = {
 	visible = function(source)
-		
+
 	end,
 }
 ----------------------------------------------------------------
@@ -471,10 +476,11 @@ dgsRenderer["dgs-dxmenu"] = function(source,x,y,w,h,mx,my,cx,cy,enabledInherited
 			drawPosY = drawPosY+separatorGap
 			if text == nil then	--If no text specified, use "line" instead
 				dxDrawImage(x+drawPosX+separatorLineStart,y+drawPosY,separatorLineEnd-separatorLineStart,separatorHeight,_,0,0,0,separatorTextColor,isPostGUI,rndtgt)
+				drawPosY = drawPosY+separatorHeight
 			else	--Use text
 				dgsDrawText(text,x+drawPosX+itemTextOffset,y+drawPosY,x+drawPosX+itemTextOffset+drawWidth,y+drawPosY+itemHeight,separatorTextColor,textSize[1],textSize[2],font,"left","center",false,false,isPostGUI,colorCoded,subPixelPositioning,0,0,0,0,shadowOffsetX,shadowOffsetY,shadowColor,shadowIsOutline,shadowFont)
+				drawPosY = drawPosY+itemHeight
 			end
-			drawPosY = drawPosY+separatorHeight
 			drawPosY = drawPosY+separatorGap
 		else
 			drawPosY = drawPosY+itemGap


### PR DESCRIPTION
## Problem Description
When using [`dgsMenuAddSeparator(menu, "--- View Options ---")`](https://wiki.multitheftauto.com/wiki/DgsMenuAddSeparator) with text, the separator doesn't provide adequate height/gap spacing for the text, making it appear cramped and poorly formatted. Line separators without text work correctly.
![image](https://github.com/user-attachments/assets/3d0e2946-9200-42a9-a1c1-88f999cce3a1)

## Root Cause
The menu was using `separatorHeight` for both line and text separators. `separatorHeight` is designed for thin line separators, not text separators which need more vertical space.

## Solution
![image](https://github.com/user-attachments/assets/cb065360-c1bf-4eab-abe6-39ac88c9ee2a)
![image](https://github.com/user-attachments/assets/ba374409-aa9e-4338-b3a5-3efda8a8d3cb)
