### PR TITLE
fix dgsMenuRemoveItem function to correctly remove items from the menu

### DIFF
--- a/Core/menu.lua
+++ b/Core/menu.lua
@@ -344,7 +344,8 @@ function dgsMenuRemoveItem(menu,uniqueID)
 		if parentUniqueID == 0 then	--Root
 			for i=1,#eleData.itemData do	--Find item in root
 				if eleData.itemData[i] == item then
-					table.remove(eleData.itemData[i],item)	--Remove from root
+					table.remove(eleData.itemData,i)	--Remove from root
+					break
 				end
 			end
 		else
@@ -353,6 +354,7 @@ function dgsMenuRemoveItem(menu,uniqueID)
 				for i=1,#parent[3] do	--Find item in parent
 					if parent[3][i] == item then
 						table.remove(parent[3],i)	--Remove from parent
+						break
 					end
 				end
 			end


### PR DESCRIPTION
## Problem Description
[dgsMenuRemoveItem(menu, itemID)](https://wiki.multitheftauto.com/wiki/DgsMenuRemoveItem) throws error: `bad argument #2 to 'remove' (number expected, got table)` at line 352.

### Root Cause
Incorrect `table.remove()` usage in `dgsMenuRemoveItem` function:
- `table.remove(eleData.itemData[i], item)` passes a table object instead of index number
- `table.remove()` expects `table.remove(table, index)` where index is a number

## Solution
Fixed incorrect `table.remove()` calls and added safety breaks